### PR TITLE
Fixed the errors on MAC OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,15 +75,9 @@ OPTCXXFLAGS ?=
 DBGCXXFLAGS ?= -g ${GCOVFLAGS}
 
 # Common warning flags shared by both C and C++.
-WARNFLAGS := -W -pedantic-errors -Wextra -Werror \
+WARNFLAGS := -W -pedantic-errors -Wextra \
              -Wformat -Wformat-nonliteral -Wpointer-arith \
-             -Wcast-align -Wconversion -Wall -Werror
-
-# Sum up the flags.
-CXXFLAGS := -O ${WARNFLAGS} ${DBGCXXFLAGS} ${OPTCXXFLAGS} -std=c++0x
-
-# Linker flags.
-LDFLAGS := -Wall
+             -Wcast-align -Wconversion -Wall 
 
 ##########################################
 # Xerces settings
@@ -93,6 +87,12 @@ XERCES_ROOT ?= /usr
 XERCES_INC := $(XERCES_ROOT)/include
 XERCES_LIB := $(XERCES_ROOT)/lib
 XERCES_LDFLAGS := -L$(XERCES_LIB) -lxerces-c
+
+# Sum up the flags.
+CXXFLAGS := -O ${WARNFLAGS} -I${XERCES_INC} ${DBGCXXFLAGS} ${OPTCXXFLAGS} -std=c++0x
+
+# Linker flags.
+LDFLAGS := -Wall ${XERCES_LDFLAGS}
 
 ##########################################
 # Targets

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This command will download a set of trace files from https://github.com/Sv3n/DRA
 
 The tool was verified on Ubuntu 14.04 using:
 
- * xerces-c (libxerces-c-dev) - v3.1 with Xerces development package
+ * xerces-c (libxerces-c-dev) - v3.1 with Xerces development package. If your Xerces package is not installed in /usr directory, Please specifiy the Xerces root directory when run the make command. For example __make XERCES_ROOT=/opt/local__.
  * gcc - v4.4.3
 
 ## 3. Directory Structure

--- a/src/CmdScheduler.cc
+++ b/src/CmdScheduler.cc
@@ -508,13 +508,13 @@ int64_t cmdScheduler::getRWTP(int64_t transType, const MemorySpecification& memS
     case MemoryType::LPDDR2:
     case MemoryType::LPDDR3:
       tRWTP_init = memArchSpec.burstLength / memArchSpec.dataRate +
-                   max(0L, memTimingSpec.RTP - 2);
+                   max(0LL, memTimingSpec.RTP - 2LL);
       break;
 
     case MemoryType::DDR2:
       tRWTP_init = memTimingSpec.AL + memArchSpec.burstLength /
                    memArchSpec.dataRate +
-                   max(memTimingSpec.RTP, 2L) - 2;
+                   max(memTimingSpec.RTP, 2LL) - 2;
       break;
 
     case MemoryType::DDR3:

--- a/src/MemCommand.cc
+++ b/src/MemCommand.cc
@@ -98,17 +98,17 @@ int64_t MemCommand::getPrechargeOffset(const MemorySpecification& memSpec,
   // Read with auto-precharge
   if (type == MemCommand::RDA) {
     if (memType == MemoryType::DDR2) {
-      precharge_offset = B + AL - 2 + max(RTP, 2L);
+      precharge_offset = B + AL - 2 + max(RTP, 2LL);
     } else if (memType == MemoryType::DDR3) {
-      precharge_offset = AL + max(RTP, 4L);
+      precharge_offset = AL + max(RTP, 4LL);
     } else if (memType == MemoryType::DDR4) {
       precharge_offset = AL + RTP;
     } else if (memType == MemoryType::LPDDR) {
       precharge_offset = B;
     } else if (memType == MemoryType::LPDDR2) {
-      precharge_offset = B + max(0L, RTP - 2);
+      precharge_offset = B + max(0LL, RTP - 2LL);
     } else if (memType == MemoryType::LPDDR3) {
-      precharge_offset = B + max(0L, RTP - 4);
+      precharge_offset = B + max(0LL, RTP - 4LL);
     } else if (memType == MemoryType::WIDEIO_SDR) {
       precharge_offset = B;
     }


### PR DESCRIPTION
According to Éder's opinion, I preserved the "-Wconversion" option but deleted the "-Werror" option in the Makefile.  A lot of warnings generated but the program was successfully compiled and ran well.

the compilation command on my MAC is:
```
make XERCES_ROOT=/opt/local
```