### PR TITLE
Number of active banks from the bank state vector.

### DIFF
--- a/src/CommandAnalysis.h
+++ b/src/CommandAnalysis.h
@@ -171,7 +171,6 @@ class CommandAnalysis {
 
   // Memory State
   unsigned mem_state;
-  unsigned num_active_banks;
 
   // Clock cycle of first activate command when memory state changes to ACT
   int64_t first_act_cycle;
@@ -198,6 +197,9 @@ class CommandAnalysis {
   void idle_pre_update(const MemorySpecification& memSpec,
                        int64_t                     timestamp,
                        int64_t                     latest_pre_cycle);
+
+  // Returns the number of active banks according to the bank_state vector.
+  unsigned get_num_active_banks(void);
 
   void printWarningIfActive(const std::string& warning, int type, int64_t timestamp, unsigned bank);
   void printWarningIfNotActive(const std::string& warning, int type, int64_t timestamp, unsigned bank);


### PR DESCRIPTION
Minor improvement to make the code less error-prone:
- Created a method that returns the number of active banks according to the
  bank state vector. This eliminates the "num_active_banks" counter, which was
  incremented/decremented/zeroed to reflect the contents of the "bank_state"
  vector. We still have a variable with the same name, but now its scope is
  well delimited, it is assigned only once for each command and it is
  inherently consistent with the state of the banks.